### PR TITLE
b1

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.1python3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1python3.7._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1python3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1python3.8._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1python3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1python3.9._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.7._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.8._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonepython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonepython3.9._.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 fftw:
 - '3'
 fortran_compiler:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,7 +7,7 @@ channel_targets:
 libnetcdf:
 - 4.7.3
 dp_version:
-- 2.0.0.b0
+- 2.0.0.b1
 boost_cpp:
 - 1.73.0
 cuda_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - dp2.patch
 
 build:
-  number: 2
+  number: 3
   string: "py{{ py }}_{{ PKG_BUILDNUM }}_cuda{{ cuda_compiler_version }}_{{ dp_variant }}"
   skip: True  # [win or py2k]
   skip: True  # [not linux]


### PR DESCRIPTION
- bump dp to v2.0.0.b1
- MNT: Re-rendered with conda-build 3.21.4, conda-smithy 3.10.1, and conda-forge-pinning 2021.06.07.07.55.19
